### PR TITLE
fix(media): fix a bug that always showed thumbnails for image-typed media files

### DIFF
--- a/lib/widgets/media_viewer.dart
+++ b/lib/widgets/media_viewer.dart
@@ -118,6 +118,7 @@ class _MediaViewerState extends State<MediaViewer> {
 
   Widget buildImage() {
     return DynamicImage(
+      showThumbnail: false,
       image: widget.image,
       fit: BoxFit.cover,
     );


### PR DESCRIPTION
this PR resolves #58 